### PR TITLE
Refactor Method comparison

### DIFF
--- a/src/streamlit_utils/state.py
+++ b/src/streamlit_utils/state.py
@@ -6,9 +6,9 @@ Contains utilities to simplify initialization and interaction with Streamlit's
 
 """
 
+import types
 import streamlit as st
 
-from inspect import ismethod
 from typing import Any, Dict, Callable, Optional, Tuple, Type, TypeVar, overload
 
 
@@ -63,7 +63,7 @@ class StreamlitStateMetaClass(type):
         for attr_name, attr_value in cls.__dict__.items():
             if attr_name.startswith("__"):
                 continue
-            if ismethod(attr_value):
+            if isinstance(attr_value, (staticmethod, classmethod, types.MethodType)):
                 attr_value = cls.__dict__[attr_name]
                 if not isinstance(attr_value, (staticmethod, classmethod)):
                     not_class_methods += (attr_name,)


### PR DESCRIPTION
Refactor `StreamlitStateMetaClass` to use `isinstance()` to check methods instead of `ismethod()`.
The `ismethod()` function only considers `types.MethodType` and does not account for `staticmethod` or `classmethod`, causing these methods to be incorrectly classified as `not_annotated` and raising the error: "Class {cls.name!r} admits only annotated attributes."